### PR TITLE
feat: restrict manage section to staff/admin users only

### DIFF
--- a/resources/views/layouts/sidebar.blade.php
+++ b/resources/views/layouts/sidebar.blade.php
@@ -32,7 +32,8 @@
     </a>
   </li>
 
-  <!-- Manage Section -->
+  <!-- Manage Section (Only for Staff and Admin) -->
+  @if(auth()->user()->access_level >= 1)
   <li class="menu-header mt-5">
     <span class="menu-header-text">MANAGE</span>
   </li>
@@ -49,7 +50,7 @@
     </a>
   </li>
 
-  <!-- User Section -->
+  <!-- User Section (Only for Staff and Admin) -->
   <li class="menu-header mt-5">
     <span class="menu-header-text">USER</span>
   </li>
@@ -59,6 +60,7 @@
       <div>Manage Users</div>
     </a>
   </li>
+  @endif
 
   <!-- Logout -->
   <li class="menu-header mt-5">


### PR DESCRIPTION
# Add Role-Based Access Control to Sidebar Navigation

## 📋 Description
Implemented access level restrictions for the manage section in the sidebar navigation to ensure only staff and admin users can access management features.

## 🔄 Type of Change
- [x] New feature
- [x] Security enhancement
- [ ] Bug fix
- [ ] Breaking change

## ✨ Changes Made
- Added `@if(auth()->user()->access_level >= 1)` condition to manage section
- Restricted access to:
  - Manage Tools page
  - Manage Position page  
  - Manage Users page
- Improved UI security by conditionally rendering admin-only menu items

## 🔒 Security Impact
- Prevents unauthorized users from seeing management options
- Enforces role-based access control at the UI level
- Maintains clean interface for different user types

## 🧪 Testing Checklist
- [ ] Tested with regular user (access_level < 1) - manage section hidden
- [ ] Tested with staff user (access_level >= 1) - manage section visible
- [ ] Verified all manage links work correctly for authorized users
- [ ] Confirmed logout functionality remains unaffected

## 📸 Screenshots
- Before: All users could see manage section
- After: Only staff/admin users see manage options

## 🔍 Code Review Notes
- Uses Laravel's auth helper and access_level property
- Maintains existing menu structure and styling
- No breaking changes to existing functionality